### PR TITLE
chore: add windows exe to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bin/fay
+bin/fay.exe


### PR DESCRIPTION

Summary:

When building on windows the compiled file has the `.exe` file extenstion. We
don't what to commit this so adding it to the gitignore.

Test Plan:

Testing this local on a windows machine. The file no longer shows up as a
changed file.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AdeAttwood/Fay/pull/3).
* #4
* __->__ #3