### PR TITLE
ci: add deno format check to the actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Lint
         run: deno lint .
 
+      - name: Format
+        run: deno fmt --check
+
       - name: Test
         run: deno test --allow-all
 


### PR DESCRIPTION

Summary:

We are not running the check command in ci. Looks like we have some formatting
issues in the repo that need fixing. This will prevent it from happening again.

Test Plan:

Run the CI.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AdeAttwood/Fay/pull/4).
* #6
* __->__ #4