### PR TITLE
ci: trigger GitHub Actions on base branch changes for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [development]
   pull_request:
     branches: [development]
+    types: [opened, synchronize, reopened, edited]
 
 jobs:
   build:


### PR DESCRIPTION

Summary:

This commit updates the GitHub Actions workflow to trigger on changes to the
base branch of a pull request. By listening to the `pull_request` event with
the `synchronize` type, the workflow ensures that actions are triggered
whenever the base branch or commits in the pull request are updated. This
enhancement supports a stacked PR workflow where PRs depend on intermediate
branches.

Test Plan:

1. Create a new pull request targeting a base branch (e.g., `pr1 -> development`).
2. Verify that the GitHub Action runs successfully upon PR creation.
3. Change the base branch of the PR (e.g., `main -> feature-2`).
4. Confirm that the workflow is triggered by the base branch change.
5. Push new commits to the PR branch and ensure the workflow is triggered.
6. Reopen a closed PR and verify that the workflow is executed

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AdeAttwood/Fay/pull/6).
* __->__ #6
* #4