### PR TITLE
feat: allow the user to use a prompt file for there prompt

### DIFF
--- a/cli/main.ts
+++ b/cli/main.ts
@@ -94,12 +94,29 @@ const newCommand = new Command()
     agent.saveSession();
   });
 
+async function getInitalPropt(proptFile: string | undefined) {
+  if (proptFile) {
+    return await Deno.readTextFile(proptFile);
+  }
+
+  return await Input.prompt(`Prompt input`);
+}
+
 const run = new Command()
   .description("Run the interactive agent")
-  .action(async () => {
+  .option(
+    "--prompt-file <string>",
+    "A path to a file that contains the first propt you want to use",
+  )
+  .action(async ({ promptFile }) => {
     const sessions = await new SessionManager("./.git/fay/sessions").list();
     const agent = new Agent(sessions[0]);
     for (const message of agent.session.messages) {
+      printMessage(message);
+    }
+
+    const initalPropt = await getInitalPropt(promptFile);
+    for await (const message of agent.prompt(initalPropt)) {
       printMessage(message);
     }
 


### PR DESCRIPTION

Summary:

Now when calling the cli tool you can use the new `--prompt-file` flag. This
will use the content of that file as the first prompt. After this prompt it
will enter interactive mode where you can add in any additional prompts.

Test Plan:

This ATM is a manual test. It has been tested locally by running the following
steps:

1) Create a new file with a prompt
2) Run `fay run --prompt-file /path/to/file.md`

This will use the first prompt from that file then enter interactive mode

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AdeAttwood/Fay/pull/8).
* #10
* __->__ #8