### PR TITLE
feat: create new edit tool

### DIFF
--- a/tools/edit.test.ts
+++ b/tools/edit.test.ts
@@ -1,0 +1,22 @@
+import { assertEquals } from "@std/assert";
+import edit from "./edit.ts";
+
+Deno.test("edit tool", async () => {
+  const testFile = await Deno.makeTempFile();
+  await Deno.writeTextFile(testFile, "hello world");
+
+  const result = await edit.execute(
+    {
+      fileName: testFile,
+      oldContent: "world",
+      newContent: "deno",
+    },
+    { toolCallId: "edit", messages: [] },
+  );
+
+  assertEquals(result, `Successfully edited ${testFile}`);
+  const newContent = await Deno.readTextFile(testFile);
+  assertEquals(newContent, "hello deno");
+
+  await Deno.remove(testFile);
+});

--- a/tools/edit.ts
+++ b/tools/edit.ts
@@ -1,0 +1,24 @@
+import { tool } from "ai";
+import z from "zod";
+
+export default tool({
+  description: "Edit a file by replacing a string with a new one.",
+  parameters: z.object({
+    fileName: z.string().describe("The filename of the file you want to edit."),
+    oldContent: z.string().describe("The old string to be replaced."),
+    newContent: z.string().describe("The new string to replace the old one."),
+  }),
+  execute: async ({ fileName, oldContent, newContent }) => {
+    try {
+      const fileContent = await Deno.readTextFile(fileName);
+      const newFileContent = fileContent.replace(oldContent, newContent);
+      await Deno.writeTextFile(fileName, newFileContent);
+      return `Successfully edited ${fileName}`;
+    } catch (error) {
+      if (error instanceof Error) {
+        return `Error editing file: ${error.message}`;
+      }
+      return `An unknown error occurred`;
+    }
+  },
+});


### PR DESCRIPTION

Summary:
I would like to include a new edit tool for editing files. We have implemented
the range feature on the write tool however the agent does not seem to be using
it.

The edit tool would only edit parts of a file it would like to edit. For
example the parameters could be

- filePath: the path to the file it wants to edit
- oldContent: the old string it would like to search for
- newContent: the new string it would like to replace with the old content

Test Plan:
- The new tools is created
- Tests for the edit tool are created
