### PR TITLE
chore: add the edit and glob tools to the exports

### DIFF
--- a/tools/glob.test.ts
+++ b/tools/glob.test.ts
@@ -28,6 +28,28 @@ Deno.test("glob tool should find files matching the pattern", async () => {
   await Deno.remove("test_glob_dir", { recursive: true });
 });
 
+Deno.test("glob tool should ignore excluded directories", async () => {
+  await Deno.mkdir("test_glob_dir/node_modules", { recursive: true });
+  await Deno.writeTextFile("test_glob_dir/node_modules/file.txt", "content");
+  await Deno.mkdir("test_glob_dir/.git", { recursive: true });
+  await Deno.writeTextFile("test_glob_dir/.git/file.txt", "content");
+  await Deno.mkdir("test_glob_dir/obj", { recursive: true });
+  await Deno.writeTextFile("test_glob_dir/obj/file.txt", "content");
+  await Deno.mkdir("test_glob_dir/bin", { recursive: true });
+  await Deno.writeTextFile("test_glob_dir/bin/file.txt", "content");
+  await Deno.writeTextFile("test_glob_dir/file.txt", "content");
+
+  const result = await runTool("test_glob_dir/**/*.txt");
+
+  assert(result.includes("file.txt"), "includes file.txt");
+  assert(!result.includes("node_modules"), "does not include node_modules");
+  assert(!result.includes(".git"), "does not include .git");
+  assert(!result.includes("obj"), "does not include obj");
+  assert(!result.includes("bin"), "does not include bin");
+
+  await Deno.remove("test_glob_dir", { recursive: true });
+});
+
 Deno.test("glob tool should return an empty string when no files match", async () => {
   const result = await runTool("non_existent_dir/**/*.txt");
   assertEquals(result, "");

--- a/tools/mod.ts
+++ b/tools/mod.ts
@@ -2,10 +2,14 @@ import ghPullReviewReviews from "./gh_pull_request_reviews.ts";
 import read from "./read.ts";
 import run from "./run.ts";
 import write from "./write.ts";
+import edit from "./edit.ts";
+import glob from "./glob.ts";
 
 export default {
   read,
   write,
   run,
   ghPullReviewReviews,
+  edit,
+  glob,
 };


### PR DESCRIPTION

Summary:

The glob and edit tools are not currently being exported for the agent to see
them. This adds them so we can start using them.

Test Plan:

N / A

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AdeAttwood/Fay/pull/19).
* #22
* #21
* #20
* __->__ #19