### PR TITLE
feat: add diff view for edits

### DIFF
--- a/cli/main.ts
+++ b/cli/main.ts
@@ -10,6 +10,8 @@ import { Configuration } from "../agent/config.ts";
 const userHighlight = colors.yellow.bold;
 const assistantHighlight = colors.green.bold;
 const toolHighlight = colors.magenta.bold;
+const diffAdded = colors.green;
+const diffRemoved = colors.red;
 
 function formatContent(content: string) {
   const split = content.split("\n");
@@ -20,10 +22,72 @@ function formatContent(content: string) {
   return [...split.slice(0, 4), "....."];
 }
 
+function printDiff(oldText: string, newText: string) {
+  const oldLines = oldText.split("\n");
+  const newLines = newText.split("\n");
+
+  const lcsMatrix: number[][] = Array(oldLines.length + 1)
+    .fill(null)
+    .map(() => Array(newLines.length + 1).fill(0));
+
+  for (let i = 1; i <= oldLines.length; i++) {
+    for (let j = 1; j <= newLines.length; j++) {
+      if (oldLines[i - 1] === newLines[j - 1]) {
+        lcsMatrix[i][j] = lcsMatrix[i - 1][j - 1] + 1;
+      } else {
+        lcsMatrix[i][j] = Math.max(lcsMatrix[i - 1][j], lcsMatrix[i][j - 1]);
+      }
+    }
+  }
+
+  const lcs: string[] = [];
+  let i = oldLines.length;
+  let j = newLines.length;
+  while (i > 0 && j > 0) {
+    if (oldLines[i - 1] === newLines[j - 1]) {
+      lcs.unshift(oldLines[i - 1]);
+      i--;
+      j--;
+    } else if (lcsMatrix[i - 1][j] >= lcsMatrix[i][j - 1]) {
+      i--;
+    } else {
+      j--;
+    }
+  }
+
+  let oldIndex = 0;
+  let newIndex = 0;
+
+  for (const line of lcs) {
+    while (oldIndex < oldLines.length && oldLines[oldIndex] !== line) {
+      console.log(toolHighlight("┃"), diffRemoved(`-${oldLines[oldIndex]}`));
+      oldIndex++;
+    }
+    while (newIndex < newLines.length && newLines[newIndex] !== line) {
+      console.log(toolHighlight("┃"), diffAdded(`+${newLines[newIndex]}`));
+      newIndex++;
+    }
+
+    console.log(toolHighlight("┃"), line);
+    oldIndex++;
+    newIndex++;
+  }
+
+  while (oldIndex < oldLines.length) {
+    console.log(toolHighlight("┃"), diffRemoved(`-${oldLines[oldIndex]}`));
+    oldIndex++;
+  }
+
+  while (newIndex < newLines.length) {
+    console.log(toolHighlight("┃"), diffAdded(`+${newLines[newIndex]}`));
+    newIndex++;
+  }
+}
+
 function printAssistantMessage(message: CoreAssistantMessage) {
   if (typeof message.content === "string") {
     console.log(assistantHighlight("┃ ASSISTANT:"));
-    for (const line of formatContent(message.content)) {
+    for (const line of message.content.split("\n")) {
       console.log(assistantHighlight("┃ "), line);
     }
 
@@ -33,12 +97,28 @@ function printAssistantMessage(message: CoreAssistantMessage) {
   message.content.forEach((c) => {
     if (c.type === "text") {
       console.log(assistantHighlight("┃ ASSISTANT:"));
-      for (const line of formatContent(c.text)) {
+      for (const line of c.text.split("\n")) {
         console.log(assistantHighlight("┃ "), line);
       }
     }
 
     if (c.type === "tool-call") {
+      if (
+        c.toolName === "edit" &&
+        typeof c.args === "object" &&
+        c.args !== null &&
+        "fileName" in c.args &&
+        "newContent" in c.args &&
+        "oldContent" in c.args &&
+        typeof c.args.oldContent === "string" &&
+        typeof c.args.newContent === "string"
+      ) {
+        console.log(toolHighlight("┃ TOOL CALL:"), `edit(${c.args.fileName})`);
+        printDiff(c.args.oldContent, c.args.newContent);
+
+        return;
+      }
+
       return console.log(
         toolHighlight("┃ TOOL CALL:"),
         `${c.toolName}(${JSON.stringify(c.args)});`,
@@ -49,11 +129,15 @@ function printAssistantMessage(message: CoreAssistantMessage) {
 
 function printToolMessage(message: CoreToolMessage) {
   message.content.forEach((c) => {
-    console.log(toolHighlight("┃ TOOL RESULT:"));
     const stringResult = typeof c.result === "string"
       ? c.result
       : JSON.stringify(c.result || "", undefined, 2);
 
+    if (stringResult.trim().length === 0) {
+      return;
+    }
+
+    console.log(toolHighlight("┃ TOOL RESULT:"));
     for (const line of formatContent(stringResult)) {
       console.log(toolHighlight("┃ "), line);
     }


### PR DESCRIPTION

Summary:

This adds a new diff view when the assistant uses the `edit` tool.
This makes it easier to see what changes the assistant is making.

Test Plan:

Run the cli and ask the assistant to edit a file.
You should see a diff view of the changes.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AdeAttwood/Fay/pull/22).
* #23
* __->__ #22