### PR TITLE
docs: document slash commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,10 @@ the agent, they are usually project specific. The default value is
   ]
 }
 ```
+
+## Slash Commands
+
+| Command   | Description                                                |
+| :-------- | :--------------------------------------------------------- |
+| `/open`   | Opens the default editor (`$EDITOR`) for multi-line input. |
+| `/system` | Displays the current system prompt.                        |


### PR DESCRIPTION

Summary:

New users are not aware of the available slash commands, making it difficult to use the CLI effectively. This change adds a "Slash Commands" section to the `README.md` file.

Test Plan:

n/a
