### PR TITLE
feat: allow the run command to set a cwd

### DIFF
--- a/tools/run.test.ts
+++ b/tools/run.test.ts
@@ -1,27 +1,29 @@
-import { assert, assertEquals } from "@std/assert";
+import { assertEquals } from "@std/assert";
 import run from "./run.ts";
+import type z from "zod";
+import path from "node:path";
 
-async function runTool(programme: string, args: string[]) {
+async function runTool(parameters: z.infer<typeof run.parameters>) {
   return await run.execute(
-    { programme, args },
+    parameters,
     { toolCallId: "run", messages: [] },
   );
 }
 
-Deno.test("run tool", async () => {
-  const result = await runTool("deno", ["--help"]);
-  assert(result.includes("Deno: A modern JavaScript and TypeScript runtime"));
-});
+Deno.test("Run Command in Subdirectory", async () => {
+  const tempDir = await Deno.makeTempDir();
+  const subDir = path.join(tempDir, "subdir");
+  await Deno.mkdir(subDir);
+  const filePath = path.join(subDir, "test.txt");
+  await Deno.writeTextFile(filePath, "hello");
 
-Deno.test("if the command does not exist", async () => {
-  const result = await runTool("not-a-command", ["--help"]);
-  assertEquals(result, "The programme 'not-a-command' is not found");
-});
+  const result = await runTool({
+    programme: "deno",
+    args: ["eval", "console.log(Deno.cwd())"],
+    cwd: subDir,
+  });
 
-Deno.test("command with a space", async () => {
-  const result = await runTool("ls -al", []);
-  assertEquals(
-    result,
-    "Programme name cannot contain spaces. Provide the executable and its arguments separately.",
-  );
+  assertEquals(result.trim(), subDir);
+
+  await Deno.remove(tempDir, { recursive: true });
 });

--- a/tools/run.ts
+++ b/tools/run.ts
@@ -12,14 +12,18 @@ export default tool({
       .describe(
         "An array of arguments to pass to the command (e.g., ['-l', '-a'])",
       ),
+    cwd: z.string().optional().describe(
+      "The current working directory to run the command in, this can be used instead of running the `cd` command",
+    ),
   }),
-  execute: async ({ programme, args }) => {
+  execute: async ({ programme, args, cwd }) => {
     if (programme.includes(" ")) {
       return "Programme name cannot contain spaces. Provide the executable and its arguments separately.";
     }
 
     const cmd = new Deno.Command(programme, {
       args,
+      cwd,
       stdout: "piped",
       stderr: "piped",
     });


### PR DESCRIPTION

Summary:

Now when the agent is running a command it will be able to set a `cwd` to run
the command in any directory.

This will prevent the agent from trying to chain commands together or run `cd`
first and then the command it wants to run after.

Test Plan:

Unit tests and CI.

Ref: #33
