### PR TITLE
fix: preserve the message when canceling mid stream

### DIFF
--- a/agent/agent.ts
+++ b/agent/agent.ts
@@ -76,6 +76,8 @@ export class Agent {
 
           if (!existing) {
             this.session.messages.push(message);
+            this.saveSession();
+
             messageQueue.push(message);
           }
         }


### PR DESCRIPTION

Summary:

When you write out your prompt and get the agent to complete a relatively large
task, you know quite quickly if it's going in the correct direction. When it
starts going off track, you can cancel the agent and start it up again.

In this scenario, all the messages are lots from the session. We would really
like this to keep the messages so it will have the context of what we don't
want to do.

There is also the case where it gets stuck and keeps making tool calls. It
would be nice to be able to stop it and nudge it in the right direction.

This now saves the session to disk when ever there is a new message come in.
Not just at the end of the stream.

Test Plan:

This has been used locally. Don't think there are any tests for this ATM.

Ref: #34

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AdeAttwood/Fay/pull/36).
* #37
* __->__ #36