### PR TITLE
feat: new session prompt for title

### DIFF
--- a/agent/agent.ts
+++ b/agent/agent.ts
@@ -76,6 +76,8 @@ export class Agent {
 
           if (!existing) {
             this.session.messages.push(message);
+            this.saveSession();
+
             messageQueue.push(message);
           }
         }

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -18,12 +18,17 @@ const list = new Command()
 const newCommand = new Command()
   .description("Create a new session")
   .option("--title <string>", "The title of the new session")
-  .action(({ title }) => {
-    if (typeof title === "undefined") {
+  .action(async ({ title }) => {
+    let sessionTitle = title;
+    if (typeof sessionTitle === "undefined") {
+      sessionTitle = await Input.prompt("Session title");
+    }
+
+    if (typeof sessionTitle === "undefined") {
       throw new Error("Session title is required");
     }
 
-    const agent = Agent.new({ title });
+    const agent = Agent.new({ title: sessionTitle });
     agent.saveSession();
   });
 


### PR DESCRIPTION

Summary:

When creating a new session the `--title` flag is now optional. If you don't
provide one it will prompt you to enter one in the interactive prompt.

Test Plan:

This has been manually tested locally.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AdeAttwood/Fay/pull/37).
* __->__ #37
* #36