### PR TITLE
fix: make sure the session dir exists

### DIFF
--- a/cli/main.ts
+++ b/cli/main.ts
@@ -32,6 +32,7 @@ const newCommand = new Command()
       throw new Error("Session title is required");
     }
 
+    new SessionManager("./.git/fay/sessions");
     const agent = Agent.new({ title: sessionTitle });
     agent.saveSession();
   });


### PR DESCRIPTION

If you run the new session command for the first time, it fails because the
session dir is not been created yet.
