### PR TITLE
fix: make use the formatter supports string run args

### DIFF
--- a/cli/formatter/index.ts
+++ b/cli/formatter/index.ts
@@ -57,8 +57,10 @@ const toolCallSchema = z.union([
     toolName: z.literal("run"),
     args: z.object({
       programme: z.string(),
-      args: z
-        .array(z.string()),
+      args: z.union([
+        z.array(z.string()),
+        z.string(),
+      ]),
       cwd: z.string().optional(),
     }),
   }),
@@ -215,10 +217,19 @@ function printToolMessage(
     }
 
     if (toolCall.toolName === "run") {
+      let args = toolCall.args.args;
+      if (typeof args === "string") {
+        try {
+          args = JSON.parse(args) as string[];
+        } catch (_) {
+          args = [args as string];
+        }
+      }
+
       return format.write({
         type: "run",
         programme: toolCall.args.programme,
-        args: toolCall.args.args,
+        args,
         result: stringResult,
       });
     }


### PR DESCRIPTION

Summary:

The run command has recently been able to run commands with strings as the
args. The output formatter did not recognize this and failed to output
anything.

This now makes sure we handle strings as params coming into the run tool.

Test Plan:

This has been tested locally with the interactive cli and the markdown
formatter.
