### PR TITLE
feat: add run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,4 @@ They can be typed into the interactive input.
 | :-------- | :--------------------------------------------------------- |
 | `/open`   | Opens the default editor (`$EDITOR`) for multi-line input. |
 | `/system` | Displays the current system prompt.                        |
+| `/run`    | Runs a shell command via Nushell and displays the output.  |

--- a/agent/config.ts
+++ b/agent/config.ts
@@ -14,6 +14,22 @@ export interface AgentConfig {
    * agent context.
    */
   contextFiles?: string[];
+  /**
+   * The shell to run commands in. The command string to run will be added as a
+   * single argument at the end of the args.
+   *
+   * For example:
+   *
+   * { command: "bash", args: "-c" }
+   *
+   * Will produce the command
+   *
+   * bash -c "ls -al"
+   */
+  shell?: {
+    command: string;
+    args: string[];
+  };
 }
 
 export class Configuration {
@@ -63,5 +79,14 @@ export class Configuration {
 
   public contextFiles(): string[] {
     return this.config.contextFiles || ["AGENTS.md"];
+  }
+
+  public shell() {
+    return (
+      this.config.shell ?? {
+        command: "nu",
+        args: ["-c"],
+      }
+    );
   }
 }

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -62,6 +62,7 @@ async function getPrompt(agent: Agent) {
     suggestions: [
       "/open",
       "/system",
+      "/run",
     ],
   });
 
@@ -72,10 +73,20 @@ async function getPrompt(agent: Agent) {
 
     case "/open":
       return await getInputFromEditor();
-
-    default:
-      return input;
   }
+
+  if (input.startsWith("/run")) {
+    const commandString = input.substring(4);
+    const shell = agent.config.shell();
+    const args = [...shell.args, commandString];
+    const result = await new Deno.Command(shell.command, { args }).output();
+
+    return (
+      "Run: " + commandString + "\n\n" + new TextDecoder().decode(result.stdout)
+    );
+  }
+
+  return input;
 }
 
 async function getInitalPrompt(


### PR DESCRIPTION

Summary:

Added a new `/run` command to the CLI that allows users to execute shell
commands via Nushell and display the output directly in the interface. This
enhances interactivity by enabling quick shell operations without leaving
the tool.

Test Plan:

Test the command by running `/run ls` in the CLI and verifying the output is
displayed correctly. Ensure it handles various commands and errors
appropriately.
