### PR TITLE
style: fix spelling of "initial" in cli/main.ts

### DIFF
--- a/cli/main.ts
+++ b/cli/main.ts
@@ -114,7 +114,7 @@ async function getPrompt(agent: Agent) {
   return input;
 }
 
-async function getInitalPrompt(
+async function getInitialPrompt(
   agent: Agent,
   prompt: string | undefined,
   promptFile: string | undefined,
@@ -149,9 +149,9 @@ const run = new Command()
       formatMessage(message, agent.session.messages, consoleFormat);
     }
 
-    const initalPrompt = await getInitalPrompt(agent, prompt, promptFile);
-    if (initalPrompt) {
-      for await (const message of agent.prompt(initalPrompt)) {
+    const initialPrompt = await getInitialPrompt(agent, prompt, promptFile);
+    if (initialPrompt) {
+      for await (const message of agent.prompt(initialPrompt)) {
         formatMessage(message, agent.session.messages, consoleFormat);
       }
     }


### PR DESCRIPTION

Summary:

Corrected "inital" to "initial" in the getInitialPrompt function and related variable names in cli/main.ts.

Test Plan:

No tests required, as this is a minor spelling correction that does not affect functionality.
