### PR TITLE
fix: let the llm know if a edit failed

### DIFF
--- a/tools/edit.ts
+++ b/tools/edit.ts
@@ -12,6 +12,10 @@ export default tool({
     try {
       const fileContent = await Deno.readTextFile(fileName);
       const newFileContent = fileContent.replace(oldContent, newContent);
+      if (fileContent === newFileContent) {
+        return "Error: edit has not been made, try reading the file again";
+      }
+
       await Deno.writeTextFile(fileName, newFileContent);
       return `Successfully edited ${fileName}`;
     } catch (error) {


### PR DESCRIPTION

When the llm uses the edit tool, sometimes the source file is out of date. When
this happens the edit dose not work. If this happens we now let the llm know so
it can read the file again.
