### PR TITLE
fix: update the preflight duplicate test entries

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -2,9 +2,9 @@
   "workspace": ["agent", "cli", "tools", "which"],
   "tasks": {
     "compile:cli": "deno compile --unstable-raw-imports --allow-run --allow-read --allow-write --allow-env --allow-net -o bin/fay ./cli/main.ts",
-    "preflight:test": "deno lint .",
-    "preflight:format": "deno fmt --check",
-    "preflight:test": "deno test --allow-all",
+    "preflight:lint": "deno lint --unstable-raw-imports .",
+    "preflight:format": "deno fmt --check .",
+    "preflight:test": "deno test --allow-all --unstable-raw-imports",
     "preflight:compile": { "dependencies": ["compile:cli"] }
   },
   "imports": {


### PR DESCRIPTION

The lint job is incorrectly named test. This is getting overridden by actual
test job and never getting run.

Now we have proper linting in the tasks.
