### PR TITLE
refactor: formatter interface to use specific format methods

### DIFF
--- a/cli/formatter/format-ascii.ts
+++ b/cli/formatter/format-ascii.ts
@@ -8,81 +8,104 @@ const diffAdded = colors.green;
 const diffRemoved = colors.red;
 
 export const consoleFormat: Format = {
-  write(item: FormatItem) {
-    switch (item.type) {
-      case "user-message":
-        console.log(userHighlight("┃ USER:"));
-        console.log(userHighlight("┃"));
-        for (const line of item.content.split("\n")) {
-          console.log(userHighlight("┃"), line);
-        }
-        console.log(userHighlight("┃"));
-        return;
-      case "assistant-message":
-        console.log(assistantHighlight("┃ ASSISTANT:"));
-        console.log(assistantHighlight("┃"));
-        for (const line of item.content.split("\n")) {
-          console.log(assistantHighlight("┃"), line);
-        }
-        console.log(assistantHighlight("┃"));
-        return;
-      case "edit":
-        console.log(toolHighlight("┃ EDIT:"), item.fileName);
-        console.log(toolHighlight("┃"));
-        item.content.forEach((line) => {
-          if (line.type === "added") {
-            console.log(toolHighlight("┃"), diffAdded("+ " + line.content));
-          } else if (line.type === "removed") {
-            console.log(toolHighlight("┃"), diffRemoved("+ " + line.content));
-          } else {
-            console.log(toolHighlight("┃"), "  " + line.content);
-          }
-        });
-        console.log(toolHighlight("┃"));
-        return;
-      case "read":
-      case "write":
-        console.log(
-          toolHighlight(`┃ ${item.type.toUpperCase()}:`),
-          item.fileName,
-        );
-        console.log(toolHighlight("┃"));
-        for (const line of formatContent(item.content)) {
-          console.log(toolHighlight("┃"), line);
-        }
-        console.log(toolHighlight("┃"));
-        return;
-      case "glob":
-        console.log(toolHighlight("┃ GLOB:"), item.pattern);
-        console.log(toolHighlight("┃"));
-        for (const line of item.content.split("\n")) {
-          console.log(toolHighlight("┃"), line);
-        }
-        console.log(toolHighlight("┃"));
-        return;
-      case "run":
-        console.log(toolHighlight("┃"));
-        console.log(
-          toolHighlight("┃ RUN:"),
-          item.programme,
-          item.args.join(" "),
-        );
-        console.log(toolHighlight("┃"));
-        for (const line of item.result.split("\n")) {
-          console.log(toolHighlight("┃"), line);
-        }
-        console.log(toolHighlight("┃"));
-        return;
-      case "tool-result":
-      case "review-comments":
-        console.log(toolHighlight(`┃ ${item.type.toUpperCase()}:`));
-        console.log(toolHighlight("┃"));
-        for (const line of item.content.split("\n")) {
-          console.log(toolHighlight("┃"), line);
-        }
-        console.log(toolHighlight("┃"));
-        return;
+  formatUserMessage(item: Extract<FormatItem, { type: "user-message" }>) {
+    console.log(userHighlight("┃ USER:"));
+    console.log(userHighlight("┃"));
+    for (const line of item.content.split("\n")) {
+      console.log(userHighlight("┃"), line);
     }
+    console.log(userHighlight("┃"));
+  },
+
+  formatAssistantMessage(
+    item: Extract<FormatItem, { type: "assistant-message" }>,
+  ) {
+    console.log(assistantHighlight("┃ ASSISTANT:"));
+    console.log(assistantHighlight("┃"));
+    for (const line of item.content.split("\n")) {
+      console.log(assistantHighlight("┃"), line);
+    }
+    console.log(assistantHighlight("┃"));
+  },
+
+  formatEdit(item: Extract<FormatItem, { type: "edit" }>) {
+    console.log(toolHighlight("┃ EDIT:"), item.fileName);
+    console.log(toolHighlight("┃"));
+    item.content.forEach((line) => {
+      if (line.type === "added") {
+        console.log(toolHighlight("┃"), diffAdded("+ " + line.content));
+      } else if (line.type === "removed") {
+        console.log(toolHighlight("┃"), diffRemoved("- " + line.content));
+      } else {
+        console.log(toolHighlight("┃"), "  " + line.content);
+      }
+    });
+    console.log(toolHighlight("┃"));
+  },
+
+  formatRead(item: Extract<FormatItem, { type: "read" }>) {
+    console.log(
+      toolHighlight(`┃ READ:`),
+      item.fileName,
+    );
+    console.log(toolHighlight("┃"));
+    for (const line of formatContent(item.content)) {
+      console.log(toolHighlight("┃"), line);
+    }
+    console.log(toolHighlight("┃"));
+  },
+
+  formatWrite(item: Extract<FormatItem, { type: "write" }>) {
+    console.log(
+      toolHighlight(`┃ WRITE:`),
+      item.fileName,
+    );
+    console.log(toolHighlight("┃"));
+    for (const line of formatContent(item.content)) {
+      console.log(toolHighlight("┃"), line);
+    }
+    console.log(toolHighlight("┃"));
+  },
+
+  formatRun(item: Extract<FormatItem, { type: "run" }>) {
+    console.log(toolHighlight("┃"));
+    console.log(
+      toolHighlight("┃ RUN:"),
+      item.programme,
+      item.args.join(" "),
+    );
+    console.log(toolHighlight("┃"));
+    for (const line of item.result.split("\n")) {
+      console.log(toolHighlight("┃"), line);
+    }
+    console.log(toolHighlight("┃"));
+  },
+
+  formatGlob(item: Extract<FormatItem, { type: "glob" }>) {
+    console.log(toolHighlight("┃ GLOB:"), item.pattern);
+    console.log(toolHighlight("┃"));
+    for (const line of item.content.split("\n")) {
+      console.log(toolHighlight("┃"), line);
+    }
+    console.log(toolHighlight("┃"));
+  },
+
+  formatReviewComments(item: Extract<FormatItem, { type: "review-comments" }>) {
+    console.log(toolHighlight(`┃ REVIEW-COMMENTS:`));
+    console.log(toolHighlight("┃"));
+    for (const line of item.content.split("\n")) {
+      console.log(toolHighlight("┃"), line);
+    }
+    console.log(toolHighlight("┃"));
+  },
+
+  formatToolResult(item: Extract<FormatItem, { type: "tool-result" }>) {
+    console.log(toolHighlight(`┃ TOOL-RESULT:`));
+    console.log(toolHighlight("┃"));
+    for (const line of item.content.split("\n")) {
+      console.log(toolHighlight("┃"), line);
+    }
+    console.log(toolHighlight("┃"));
   },
 };
 

--- a/cli/formatter/format-markdown.ts
+++ b/cli/formatter/format-markdown.ts
@@ -18,62 +18,74 @@ function details(
 }
 
 export const markdownFormat: Format = {
-  write(item: FormatItem) {
-    switch (item.type) {
-      case "user-message":
-        console.log("## USER:");
-        console.log("");
-        console.log(item.content);
-        console.log("");
-        return;
-      case "assistant-message":
-        console.log("## ASSISTANT:");
-        console.log("");
-        console.log(item.content);
-        console.log("");
-        return;
-      case "edit":
-        details(
-          "EDIT: " + item.fileName,
-          item.content.map((line) => {
-            if (line.type === "added") {
-              return "+ " + line.content;
-            } else if (line.type === "removed") {
-              return "- " + line.content;
-            } else {
-              return "  " + line.content;
-            }
-          }).join("\n"),
-          "diff",
-        );
-        return;
-      case "read":
-      case "write":
-        details(
-          `${item.type.toUpperCase()}: ${item.fileName}`,
-          item.content,
-          item.fileName.split(".").pop() || "txt",
-        );
-        return;
-      case "glob":
-        details("GLOB: `" + item.pattern + "`", item.content);
-        return;
-      case "run":
-        details(
-          "RUN: `" + item.programme + " " + item.args.join(" ") + "`",
-          item.result,
-        );
-        return;
-      case "review-comments":
-        console.log("## REVIEW COMMENTS:");
-        console.log("");
-        console.log(item.content);
-        console.log("");
-        return;
-      case "tool-result":
-        console.log(`## TOOL RESULT:`);
-        details("Tool Result", item.content);
-        return;
-    }
+  formatUserMessage(item: Extract<FormatItem, { type: "user-message" }>) {
+    console.log("## USER:");
+    console.log("");
+    console.log(item.content);
+    console.log("");
+  },
+
+  formatAssistantMessage(
+    item: Extract<FormatItem, { type: "assistant-message" }>,
+  ) {
+    console.log("## ASSISTANT:");
+    console.log("");
+    console.log(item.content);
+    console.log("");
+  },
+
+  formatEdit(item: Extract<FormatItem, { type: "edit" }>) {
+    details(
+      "EDIT: " + item.fileName,
+      item.content.map((line) => {
+        if (line.type === "added") {
+          return "+ " + line.content;
+        } else if (line.type === "removed") {
+          return "- " + line.content;
+        } else {
+          return "  " + line.content;
+        }
+      }).join("\n"),
+      "diff",
+    );
+  },
+
+  formatRead(item: Extract<FormatItem, { type: "read" }>) {
+    details(
+      `READ: ${item.fileName}`,
+      item.content,
+      item.fileName.split(".").pop() || "txt",
+    );
+  },
+
+  formatWrite(item: Extract<FormatItem, { type: "write" }>) {
+    details(
+      `WRITE: ${item.fileName}`,
+      item.content,
+      item.fileName.split(".").pop() || "txt",
+    );
+  },
+
+  formatRun(item: Extract<FormatItem, { type: "run" }>) {
+    details(
+      "RUN: `" + item.programme + " " + item.args.join(" ") + "`",
+      item.result,
+    );
+  },
+
+  formatGlob(item: Extract<FormatItem, { type: "glob" }>) {
+    details("GLOB: `" + item.pattern + "`", item.content);
+  },
+
+  formatReviewComments(item: Extract<FormatItem, { type: "review-comments" }>) {
+    console.log("## REVIEW COMMENTS:");
+    console.log("");
+    console.log(item.content);
+    console.log("");
+  },
+
+  formatToolResult(item: Extract<FormatItem, { type: "tool-result" }>) {
+    console.log(`## TOOL RESULT:`);
+    details("Tool Result", item.content);
   },
 };

--- a/cli/formatter/index.ts
+++ b/cli/formatter/index.ts
@@ -18,12 +18,36 @@ export type FormatItem =
   | { type: "tool-result"; content: string };
 
 export type DiffItem = {
-  "type": "added" | "removed" | "context";
-  "content": string;
+  type: "added" | "removed" | "context";
+  content: string;
 };
 
 export interface Format {
-  write(type: FormatItem): void;
+  formatUserMessage: (
+    item: Extract<FormatItem, { type: "user-message" }>,
+  ) => void;
+
+  formatAssistantMessage: (
+    item: Extract<FormatItem, { type: "assistant-message" }>,
+  ) => void;
+
+  formatEdit: (item: Extract<FormatItem, { type: "edit" }>) => void;
+
+  formatRead: (item: Extract<FormatItem, { type: "read" }>) => void;
+
+  formatWrite: (item: Extract<FormatItem, { type: "write" }>) => void;
+
+  formatRun: (item: Extract<FormatItem, { type: "run" }>) => void;
+
+  formatGlob: (item: Extract<FormatItem, { type: "glob" }>) => void;
+
+  formatReviewComments: (
+    item: Extract<FormatItem, { type: "review-comments" }>,
+  ) => void;
+
+  formatToolResult: (
+    item: Extract<FormatItem, { type: "tool-result" }>,
+  ) => void;
 }
 
 const toolCallSchema = z.union([
@@ -58,10 +82,7 @@ const toolCallSchema = z.union([
     toolName: z.literal("run"),
     args: z.object({
       programme: z.string(),
-      args: z.union([
-        z.array(z.string()),
-        z.string(),
-      ]),
+      args: z.union([z.array(z.string()), z.string()]),
       cwd: z.string().optional(),
     }),
   }),
@@ -142,7 +163,7 @@ function printAssistantMessage(
   format: Format,
 ) {
   if (typeof message.content === "string") {
-    return format.write({
+    return format.formatAssistantMessage({
       type: "assistant-message",
       content: message.content,
     });
@@ -150,7 +171,7 @@ function printAssistantMessage(
 
   message.content.forEach((c) => {
     if (c.type === "text") {
-      return format.write({
+      return format.formatAssistantMessage({
         type: "assistant-message",
         content: c.text,
       });
@@ -163,7 +184,8 @@ function getToolCall(id: string, messages: InternalMessage[]) {
     if (message.role === "assistant") {
       for (const content of message.content) {
         if (
-          typeof content !== "string" && content.type === "tool-call" &&
+          typeof content !== "string" &&
+          content.type === "tool-call" &&
           content.toolCallId == id
         ) {
           return content;
@@ -196,7 +218,7 @@ function printToolMessage(
       : JSON.stringify(c.result || "", undefined, 2);
 
     if (toolCall.toolName === "edit") {
-      return format.write({
+      return format.formatEdit({
         type: "edit",
         fileName: toolCall.args.fileName,
         content: formatDiff(toolCall.args.oldContent, toolCall.args.newContent),
@@ -204,7 +226,7 @@ function printToolMessage(
     }
 
     if (toolCall.toolName === "read") {
-      return format.write({
+      return format.formatRead({
         type: "read",
         fileName: toolCall.args.fileName,
         content: stringResult,
@@ -212,7 +234,7 @@ function printToolMessage(
     }
 
     if (toolCall.toolName === "write") {
-      return format.write({
+      return format.formatWrite({
         type: "write",
         fileName: toolCall.args.fileName,
         content: toolCall.args.content,
@@ -220,7 +242,7 @@ function printToolMessage(
     }
 
     if (toolCall.toolName === "glob") {
-      return format.write({
+      return format.formatGlob({
         type: "glob",
         pattern: toolCall.args.pattern,
         content: stringResult,
@@ -237,7 +259,7 @@ function printToolMessage(
         }
       }
 
-      return format.write({
+      return format.formatRun({
         type: "run",
         programme: toolCall.args.programme,
         args,
@@ -246,7 +268,7 @@ function printToolMessage(
     }
 
     if (toolCall.toolName === "ghPullReviewReviews") {
-      return format.write({
+      return format.formatReviewComments({
         type: "review-comments",
         content: stringResult,
       });
@@ -256,7 +278,7 @@ function printToolMessage(
       return;
     }
 
-    format.write({
+    format.formatToolResult({
       type: "tool-result",
       content: stringResult,
     });
@@ -278,7 +300,7 @@ export function formatMessage(
 ) {
   switch (message.role) {
     case "user":
-      return format.write({
+      return format.formatUserMessage({
         type: "user-message",
         content: formatUserMessageContent(message.content),
       });


### PR DESCRIPTION

Replace generic write() with dedicated format methods for each item type
in the Format interface and implementations. Update usages to call the
appropriate method. Remove unused diff.ts.
