### PR TITLE
fix: handle line endings better

### DIFF
--- a/tools/edit.test.ts
+++ b/tools/edit.test.ts
@@ -20,3 +20,63 @@ Deno.test("edit tool", async () => {
 
   await Deno.remove(testFile);
 });
+
+Deno.test("edit tool with unix line endings", async () => {
+  const testFile = await Deno.makeTempFile();
+  await Deno.writeTextFile(testFile, "hello world\r\nSome content");
+
+  const result = await edit.execute?.(
+    {
+      fileName: testFile,
+      oldContent: "hello world\nSome",
+      newContent: "my\nnew",
+    },
+    { toolCallId: "edit", messages: [] },
+  );
+
+  assertEquals(result, `Successfully edited ${testFile}`);
+  const newContent = await Deno.readTextFile(testFile);
+  assertEquals(newContent, "my\nnew content");
+
+  await Deno.remove(testFile);
+});
+
+Deno.test("edit tool with mixed line endings", async () => {
+  const testFile = await Deno.makeTempFile();
+  await Deno.writeTextFile(testFile, "hello world\r\nSome content");
+
+  const result = await edit.execute?.(
+    {
+      fileName: testFile,
+      oldContent: "hello world\r\nSome",
+      newContent: "my\nnew",
+    },
+    { toolCallId: "edit", messages: [] },
+  );
+
+  assertEquals(result, `Successfully edited ${testFile}`);
+  const newContent = await Deno.readTextFile(testFile);
+  assertEquals(newContent, "my\nnew content");
+
+  await Deno.remove(testFile);
+});
+
+Deno.test("edit tool with mixed line endings in the old content", async () => {
+  const testFile = await Deno.makeTempFile();
+  await Deno.writeTextFile(testFile, "hello world\nSome content");
+
+  const result = await edit.execute?.(
+    {
+      fileName: testFile,
+      oldContent: "hello world\r\nSome",
+      newContent: "my\nnew",
+    },
+    { toolCallId: "edit", messages: [] },
+  );
+
+  assertEquals(result, `Successfully edited ${testFile}`);
+  const newContent = await Deno.readTextFile(testFile);
+  assertEquals(newContent, "my\nnew content");
+
+  await Deno.remove(testFile);
+});

--- a/tools/edit.ts
+++ b/tools/edit.ts
@@ -10,8 +10,20 @@ export default tool({
   }),
   execute: async ({ fileName, oldContent, newContent }) => {
     try {
-      const fileContent = await Deno.readTextFile(fileName);
-      const newFileContent = fileContent.replace(oldContent, newContent);
+      const fileContent = (await Deno.readTextFile(fileName)).replace(
+        /\r\n/g,
+        "\n",
+      );
+
+      if (!fileContent.includes(oldContent.replace(/\r\n/g, "\n"))) {
+        return `Error: The old string is not in ${fileName}`;
+      }
+
+      const newFileContent = fileContent.replace(
+        oldContent.replace(/\r\n/g, "\n"),
+        newContent.replace(/\r\n/g, "\n"),
+      );
+
       if (fileContent === newFileContent) {
         return "Error: edit has not been made, try reading the file again";
       }


### PR DESCRIPTION

Summary:

When there are windows line endings in a file, the edit tool fails to add the
content.

Now when we are editing we are normalizing  all the content to unix line
endings before trying to replace the content.

Test Plan:

Unit tests.
