### PR TITLE
feat: add support for file:// URIs in buildMessageText

### DIFF
--- a/agent_client_protocol/build_message.test.ts
+++ b/agent_client_protocol/build_message.test.ts
@@ -55,6 +55,40 @@ Deno.test("Handles /agent/file resource link", () => {
   assertEquals("C:\\test.txt", result);
 });
 
+Deno.test("Handles file:// resource link", () => {
+  const result = buildMessageText(
+    {
+      log: (_: string) => {},
+    } as Context,
+    [
+      {
+        type: "resource_link",
+        name: "test.md (31:31)",
+        uri: "file:///D:/Code/src/github.com/AdeAttwood/Fay/test.md#L31:31",
+      },
+    ],
+  );
+
+  assertEquals("D:/Code/src/github.com/AdeAttwood/Fay/test.md#L31:31", result);
+});
+
+Deno.test("Handles file:// resource link without hash", () => {
+  const result = buildMessageText(
+    {
+      log: (_: string) => {},
+    } as Context,
+    [
+      {
+        type: "resource_link",
+        name: "journey-detection.md",
+        uri: "file:///D:/Code/src/github.com/AdeAttwood/Fay/test.md",
+      },
+    ],
+  );
+
+  assertEquals("D:/Code/src/github.com/AdeAttwood/Fay/test.md", result);
+});
+
 Deno.test("Handles unknown protocol resource link", () => {
   const result = buildMessageText(
     {

--- a/agent_client_protocol/build_message.ts
+++ b/agent_client_protocol/build_message.ts
@@ -22,6 +22,9 @@ export function buildMessageText(
       } else if (url.protocol == "zed:" && url.pathname == "/agent/selection") {
         const path = url.searchParams.get("path");
         if (path) message.push(path + url.hash);
+      } else if (url.protocol == "file:") {
+        const path = url.pathname.slice(1);
+        message.push(path + url.hash);
       } else {
         context.log(`Skipping unknown resource link ${JSON.stringify(block)}`);
       }


### PR DESCRIPTION

Summary:
Added handling for file:// protocol URIs in the buildMessageText function, extracting the path and appending any hash for line references. Added corresponding tests.

Test Plan:
Run the test suite, all tests pass including new ones for file:// URIs.
